### PR TITLE
Fix updating from 5.5.x & enable Shellcheck

### DIFF
--- a/.github/workflows/github-actions-shellcheck.yml
+++ b/.github/workflows/github-actions-shellcheck.yml
@@ -1,0 +1,15 @@
+on:
+  push:
+    branches:
+      - master
+
+name: "Trigger: Push action"
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@master

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -3,31 +3,30 @@
 echo "Beginning upgrade procedure."
 
 read -p "Do you wish to back up all existing databases? (y/n) " -n 1 -r
-echo    # new line
-if [[ ! $REPLY =~ ^[Nn]$ ]] ; then
-    echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."
-    MYSQL_PWD=`cat /etc/psa/.psa.shadow` mysqldump -u admin --all-databases --routines --triggers --max_allowed_packet=1G | gzip > /root/all_databases_pre_maria_upgrade.sql.gz
+echo # new line
+if [[ ! $REPLY =~ ^[Nn]$ ]]; then
+  echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."
+  MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysqldump -u admin --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz
 else
-    echo "A risk taker, I see. Carrying on with upgrade procedures without backup..."
+  echo "A risk taker, I see. Carrying on with upgrade procedures without backup..."
 fi
 
 read -p "Are you sure you wish to proceed with the upgrade to MariaDB 10.5? (y/n) " -n 1 -r
-echo    # new line
-if [[ ! $REPLY =~ ^[Yy]$ ]] ; then
-    [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
+echo # new line
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
 fi
 
-
-do_mariadb_upgrade(){
+do_mariadb_upgrade() {
 
   MDB_VER=$1
   #MAJOR_VER=$(rpm --eval '%{rhel}')
   # Gets us ID and VERSION_ID vars
   source /etc/os-release
   MAJOR_VER="${VERSION_ID:0:1}" #ex: 7 or 8 rather than 7.4 or 8.4
-  
-  if [[ "$ID" = "almalinux" ]] ; then ID=rhel; fi
-  
+
+  if [[ "$ID" = "almalinux" ]]; then ID=rhel; fi
+
   echo "Beginning upgrade to MariaDB $MDB_VER..."
 
   DATE=$(date)
@@ -38,7 +37,7 @@ name = MariaDB
 baseurl = http://yum.mariadb.org/$MDB_VER/$ID$MAJOR_VER-amd64
 module_hotfixes=1
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
-gpgcheck=1" > /etc/yum.repos.d/mariadb.repo
+gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
 
   echo "- Clearing mariadb repo cache"
   yum clean all --disablerepo="*" --enablerepo=mariadb
@@ -46,103 +45,101 @@ gpgcheck=1" > /etc/yum.repos.d/mariadb.repo
   systemctl stop mysql
 
   echo "- Removing packages"
-  rpm -e --nodeps MariaDB-server > /dev/null 2>&1
-  rpm -e --nodeps mariadb-server > /dev/null 2>&1
-  rpm -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server > /dev/null 2>&1
+  rpm -e --nodeps MariaDB-server >/dev/null 2>&1
+  rpm -e --nodeps mariadb-server >/dev/null 2>&1
+  rpm -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server >/dev/null 2>&1
 
   echo "- Updating and installing packages"
   yum -y update MariaDB-*
   yum -y install MariaDB-server MariaDB MariaDB-gssapi-server
-  
+
   echo "- Starting MariaDB $MDB_VER"
   systemctl restart mariadb
 
   echo "- Running mysql_upgrade"
-  MYSQL_PWD=`cat /etc/psa/.psa.shadow` mysql_upgrade -uadmin
+  MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
 
 }
 
 MySQL_VERS_INFO=$(mysql --version)
 
 #Consistency in repo naming, if one already exists
-if [ -f "/etc/yum.repos.d/MariaDB.repo" ] ; then
+if [ -f "/etc/yum.repos.d/MariaDB.repo" ]; then
   mv /etc/yum.repos.d/MariaDB.repo /etc/yum.repos.d/mariadb.repo
 fi
 
 systemctl stop sw-cp-server
 
 case $MySQL_VERS_INFO in
-    *"Distrib 5.5."*)
-      echo "MySQL / MariaDB 5.5 detected. Proceeding with 5.5 -> 10.0 -> 10.5"
-      rpm -e --nodeps mysql-server
-      mv -f /etc/my.cnf /etc/my.cnf.bak
-      do_mariadb_upgrade '10.0'
-      do_mariadb_upgrade '10.5'
-      ;;
-    
-    *"Distrib 5.6."*)
-      echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5"
-      
-      if [[ $(rpm -qa | grep Percona-Server-server) ]]; then
-        # Removing Percona server and disabling repo
-        rpm -e --nodeps Percona-Server-server-56
-        rpm -e --nodeps Percona-Server-shared-56
-        rpm -e --nodeps Percona-Server-client-56
-        rpm -e --nodeps Percona-Server-shared-51
-        sed -i 's/^enabled = 1/enabled = 0/' /etc/yum.repos.d/percona-original-release.repo
-      else
-        # Removing MySQL 5.6 server
-        rpm -e --nodeps mysql-server
-      fi
+*"Distrib 5.5."*)
+  echo "MySQL / MariaDB 5.5 detected. Proceeding with 5.5 -> 10.0 -> 10.5"
+  rpm -e --nodeps mysql-server
+  mv -f /etc/my.cnf /etc/my.cnf.bak
+  do_mariadb_upgrade '10.0'
+  do_mariadb_upgrade '10.5'
+  ;;
 
-      mv -f /etc/my.cnf /etc/my.cnf.bak
-      
-      do_mariadb_upgrade '10.0'
-      do_mariadb_upgrade '10.1'
-      do_mariadb_upgrade '10.2'
-      do_mariadb_upgrade '10.5'
-      ;;
-      
-    *"Distrib 10.0"*)
-      echo "MariaDB 10.0 detected. Proceeding with upgrade to 10.5"
-      mv -f /etc/my.cnf /etc/my.cnf.bak
-      do_mariadb_upgrade '10.1'
-      do_mariadb_upgrade '10.2'
-      do_mariadb_upgrade '10.5'
-      ;;
-      
-    *"Distrib 10.1"*)
-      echo "MariaDB 10.1 detected. Proceeding with upgrade to 10.5"
-      do_mariadb_upgrade '10.2'
-      do_mariadb_upgrade '10.5'
-      ;;
-      
-    *"Distrib 10.2"*)
-      echo "MariaDB 10.2 detected. Proceeding with upgrade to 10.5"
-      do_mariadb_upgrade '10.5'
-      ;;
-      
-    *"Distrib 10.3"*)
-      echo "MariaDB 10.3 detected. Proceeding with upgrade to 10.5"
-      do_mariadb_upgrade '10.5'
-      ;;
-    *"Distrib 10.4"*)
-      echo "MariaDB 10.4 detected. Proceeding with upgrade to 10.5"
-      do_mariadb_upgrade '10.5'
-      ;;
-      
-    *"Distrib 10.5"*)
-      echo "Already at 10.5. Exiting."
-      exit 1
-      ;;
-      
-      
-    *)
-      echo "Error. Unknown initial MySQL version. Aborting."
-      exit 1
-      ;;
+*"Distrib 5.6."*)
+  echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5"
+
+  if [[ $(rpm -qa | grep Percona-Server-server) ]]; then
+    # Removing Percona server and disabling repo
+    rpm -e --nodeps Percona-Server-server-56
+    rpm -e --nodeps Percona-Server-shared-56
+    rpm -e --nodeps Percona-Server-client-56
+    rpm -e --nodeps Percona-Server-shared-51
+    sed -i 's/^enabled = 1/enabled = 0/' /etc/yum.repos.d/percona-original-release.repo
+  else
+    # Removing MySQL 5.6 server
+    rpm -e --nodeps mysql-server
+  fi
+
+  mv -f /etc/my.cnf /etc/my.cnf.bak
+
+  do_mariadb_upgrade '10.0'
+  do_mariadb_upgrade '10.1'
+  do_mariadb_upgrade '10.2'
+  do_mariadb_upgrade '10.5'
+  ;;
+
+*"Distrib 10.0"*)
+  echo "MariaDB 10.0 detected. Proceeding with upgrade to 10.5"
+  mv -f /etc/my.cnf /etc/my.cnf.bak
+  do_mariadb_upgrade '10.1'
+  do_mariadb_upgrade '10.2'
+  do_mariadb_upgrade '10.5'
+  ;;
+
+*"Distrib 10.1"*)
+  echo "MariaDB 10.1 detected. Proceeding with upgrade to 10.5"
+  do_mariadb_upgrade '10.2'
+  do_mariadb_upgrade '10.5'
+  ;;
+
+*"Distrib 10.2"*)
+  echo "MariaDB 10.2 detected. Proceeding with upgrade to 10.5"
+  do_mariadb_upgrade '10.5'
+  ;;
+
+*"Distrib 10.3"*)
+  echo "MariaDB 10.3 detected. Proceeding with upgrade to 10.5"
+  do_mariadb_upgrade '10.5'
+  ;;
+*"Distrib 10.4"*)
+  echo "MariaDB 10.4 detected. Proceeding with upgrade to 10.5"
+  do_mariadb_upgrade '10.5'
+  ;;
+
+*"Distrib 10.5"*)
+  echo "Already at 10.5. Exiting."
+  exit 1
+  ;;
+
+*)
+  echo "Error. Unknown initial MySQL version. Aborting."
+  exit 1
+  ;;
 esac
-
 
 ######
 # At completion of all upgrades
@@ -174,7 +171,6 @@ systemctl disable mariadb
 systemctl enable mariadb.service
 systemctl start mariadb.service
 
-
 echo "Fixing Plesk bug MDEV-27834"
 # BUGFIX MDEV-27834: https://support.plesk.com/hc/en-us/articles/4419625529362-Plesk-Installer-fails-when-MariaDB-10-5-or-10-6-is-installed
 
@@ -182,28 +178,27 @@ mdb_ver=$(rpm -q MariaDB-shared | awk -F- '{print $3}')
 
 if echo $mdb_ver | grep -q 10.3.34; then
 
-	#rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
+  #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
   yum -y downgrade MariaDB-shared-10.3.32
-	echo "exclude=MariaDB-shared-10.3.34" >> /etc/yum.repos.d/mariadb.repo
+  echo "exclude=MariaDB-shared-10.3.34" >>/etc/yum.repos.d/mariadb.repo
 
 elif echo $mdb_ver | grep -q 10.4.24; then
 
-	#rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
+  #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
   yum -y downgrade MariaDB-shared-10.4.22
-	echo "exclude=MariaDB-shared-10.4.24" >> /etc/yum.repos.d/mariadb.repo
+  echo "exclude=MariaDB-shared-10.4.24" >>/etc/yum.repos.d/mariadb.repo
 
 elif echo $mdb_ver | grep -q 10.5.15; then
 
-	#rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
+  #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
   yum -y downgrade MariaDB-shared-10.5.13
-	echo "exclude=MariaDB-shared-10.5.15" >> /etc/yum.repos.d/mariadb.repo
+  echo "exclude=MariaDB-shared-10.5.15" >>/etc/yum.repos.d/mariadb.repo
 
-fi 
+fi
 
 # If you needed the above to install Plesk updates, now run `plesk installer update`
 
 # END BUGFIX
-
 
 echo "Informing Plesk of Changes"
 #plesk bin service_node --update local
@@ -215,6 +210,6 @@ systemctl daemon-reload
 
 # Allow commands like mysqladmin processlist without un/pw
 # Needed for logrotate
-plesk db "install plugin unix_socket soname 'auth_socket';" > /dev/null 2>&1
-plesk db "CREATE USER 'root'@'localhost' IDENTIFIED VIA unix_socket;" > /dev/null 2>&1
-plesk db "GRANT RELOAD ON *.* TO 'root'@'localhost';" > /dev/null 2>&1
+plesk db "install plugin unix_socket soname 'auth_socket';" >/dev/null 2>&1
+plesk db "CREATE USER 'root'@'localhost' IDENTIFIED VIA unix_socket;" >/dev/null 2>&1
+plesk db "GRANT RELOAD ON *.* TO 'root'@'localhost';" >/dev/null 2>&1

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -164,7 +164,13 @@ case $MySQL_VERS_INFO in
     sed -i 's/^enabled = 1/enabled = 0/' /etc/yum.repos.d/percona-original-release.repo
   else
     # Removing MySQL 5.6 server
-    rpm -e --nodeps mysql-server
+    if erroutput=$(rpm -e --nodeps mysql-server 2>&1); then
+      echo "removed mysql-server 5.6"
+    else
+      echo -e "${RED}Failed to removed MySQL-server 5.6"
+      echo -e "$erroutput ${NC}"
+      exit 1
+    fi
   fi
 
   mv -f /etc/my.cnf /etc/my.cnf.bak

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -73,7 +73,11 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
     echo -e "$erroutput ${NC}"
   fi
   echo "- Stopping current db server"
-  systemctl stop mariadb || systemctl stop mysql
+  if systemctl | grep -i "mariadb.service"; then
+    systemctl stop mariadb
+  elif systemctl | grep -i "mysql.service"; then
+    systemctl stop mysql
+  fi
 
   echo "- Removing packages"
   rpm --quiet -e --nodeps MariaDB-server

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -36,7 +36,9 @@ do_mariadb_upgrade() {
   source /etc/os-release
   MAJOR_VER="${VERSION_ID:0:1}" #ex: 7 or 8 rather than 7.4 or 8.4
 
-  if [[ "$ID" = "almalinux" ]]; then ID=rhel; fi
+  if [[ "$ID" = "almalinux" ]]; then 
+    ID=rhel; 
+  fi
 
   echo "Beginning upgrade to MariaDB $MDB_VER..."
 

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -52,8 +52,8 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   rpm -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server >/dev/null 2>&1
 
   echo "- Updating and installing packages"
-  yum -y update MariaDB-*
-  yum -y install MariaDB-server MariaDB MariaDB-gssapi-server
+  yum -y -q update MariaDB-*
+  yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
 
   echo "- Starting MariaDB $MDB_VER"
   systemctl restart mariadb
@@ -181,19 +181,19 @@ mdb_ver=$(rpm -q MariaDB-shared | awk -F- '{print $3}')
 if echo "$mdb_ver" | grep -q 10.3.34; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
-  yum -y downgrade MariaDB-shared-10.3.32
+  yum -y -q downgrade MariaDB-shared-10.3.32
   echo "exclude=MariaDB-shared-10.3.34" >>/etc/yum.repos.d/mariadb.repo
 
 elif echo "$mdb_ver" | grep -q 10.4.24; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
-  yum -y downgrade MariaDB-shared-10.4.22
+  yum -y -q downgrade MariaDB-shared-10.4.22
   echo "exclude=MariaDB-shared-10.4.24" >>/etc/yum.repos.d/mariadb.repo
 
 elif echo "$mdb_ver" | grep -q 10.5.15; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
-  yum -y downgrade MariaDB-shared-10.5.13
+  yum -y -q downgrade MariaDB-shared-10.5.13
   echo "exclude=MariaDB-shared-10.5.15" >>/etc/yum.repos.d/mariadb.repo
 
 fi

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -2,6 +2,7 @@
 
 RED='\033[0;31m'
 NC='\033[0m' # No Color
+LOG="/var/log/mairadb-upgrade.log"
 
 echo "Beginning upgrade procedure."
 
@@ -10,10 +11,10 @@ echo # new line
 if [[ ! $REPLY =~ ^[Nn]$ ]]; then
   echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."
   if erroutput=$(mysqldump -u admin -p$(cat /etc/psa/.psa.shadow) --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz 2>&1); then
-    echo "Backups successfully created"
+    echo "- Backups successfully created" | tee $LOG
   else
-    echo -e "${RED}Error:"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Error:" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
 else
@@ -40,7 +41,7 @@ do_mariadb_upgrade() {
     ID=rhel; 
   fi
 
-  echo "Beginning upgrade to MariaDB $MDB_VER..."
+  echo "Beginning upgrade to MariaDB $MDB_VER..." | tee $LOG
 
   DATE=$(date)
   if [ "$MDB_VER" = "10.0" ]; then
@@ -65,15 +66,15 @@ gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
-  echo "- Clearing mariadb repo cache"
+  echo "- Clearing mariadb repo cache" | tee $LOG
   if erroutput=$(yum clean all --disablerepo="*" --enablerepo=mariadb 2>&1); then
-    echo "mariadb repo cache cleared"
+    echo "- mariadb repo cache cleared" | tee $LOG
   else
-    echo -e "${RED}Failed to clear mariadb repo cache"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Failed to clear mariadb repo cache" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
-  echo "- Stopping current db server"
+  echo "- Stopping current db server" | tee $LOG
   if systemctl | grep -i "mariadb.service"; then
     systemctl stop mariadb
   elif systemctl | grep -i "mysql.service"; then
@@ -83,15 +84,15 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   echo "- Removing packages"
   if rpm -qa | grep "MariaDB-server" > /dev/null 2>&1; then
     if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
-      echo "MariaDB-server package erased"
+      echo "- MariaDB-server package erased" | tee $LOG
     else
-      echo -e "${RED}$erroutput ${NC}"
+      echo -e "${RED}$erroutput ${NC}" | tee $LOG
     fi
   else
     if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
-      echo "MariaDB-server package erased"
+      echo "- MariaDB-server package erased" | tee $LOG
     else
-      echo -e "${RED}$erroutput ${NC}"
+      echo -e "${RED}$erroutput ${NC}" | tee $LOG
     fi
   fi
   installed_packages=$(rpm -qa)
@@ -102,26 +103,26 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   done
   if [ ! -z $mariadb_rpm ]; then
     if erroutput=$(rpm --quiet -e --nodeps $mariadb_rpm 2>&1); then
-      echo "MariaDB packages erased"
+      echo "- MariaDB packages erased" | tee $LOG
     else
-      echo -e "${RED}$erroutput ${NC}"
+      echo -e "${RED}$erroutput ${NC}" | tee $LOG
     fi
   fi
 
   echo "- Updating and installing packages"
   if erroutput=$(yum -y -q update MariaDB-* 2>&1); then
-    echo "MariaDB packages updated"  
+    echo "- MariaDB packages updated" | tee $LOG
   else
-    echo -e "${RED}Failed to update MariaDB packages:"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Failed to update MariaDB packages:" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
 
   if erroutput=$(yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server 2>&1); then
-    echo "MariaDB-server $MDB_VER successfully installed"
+    echo "- MariaDB-server $MDB_VER successfully installed" | tee $LOG
   else
-    echo -e "${RED}Failed to installed MariaDB $MDB_VER"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Failed to installed MariaDB $MDB_VER" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
 
@@ -134,10 +135,10 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
 
   echo "- Running mysql_upgrade"
   if erroutput=$(mysql_upgrade -u admin -p$(cat /etc/psa/.psa.shadow) 2>&1); then
-    echo "MySQL/MariaDB upgrade to $MDB_VER was Successful"
+    echo "- MySQL/MariaDB upgrade to $MDB_VER was Successful" | tee $LOG
   else
-    echo -e "${RED}Failed to upgrade to MySQL/MariaDB $MDB_VER"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Failed to upgrade to MySQL/MariaDB $MDB_VER" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
 }
@@ -161,42 +162,42 @@ case $MySQL_VERS_INFO in
   ;;
 
 *"Distrib 5.6."*)
-  echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5"
+  echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5" | tee $LOG
   # shellcheck disable=SC2143
   if [[ $(rpm -qa | grep Percona-Server-server) ]]; then
     # Removing Percona server and disabling repo
     if erroutput=$(rpm -e --nodeps Percona-Server-server-56 2>&1); then
-      echo "Percona-Package erased"
+      echo "- Percona-Package erased" | tee $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package"
-      echo -e "$erroutput ${NC}"
+      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
+      echo -e "$erroutput ${NC}" | tee $LOG
     fi
     if erroutput=$(rpm -e --nodeps Percona-Server-shared-56 2>&1); then
-      echo "Percona-Package erased"
+      echo "- Percona-Package erased" | tee $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package"
-      echo -e "$erroutput ${NC}"
+      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
+      echo -e "$erroutput ${NC}" | tee $LOG
     fi
     if erroutput=$(rpm -e --nodeps Percona-Server-client-56 2>&1); then
-      echo "Percona-Package erased"
+      echo "- Percona-Package erased" | tee $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package"
-      echo -e "$erroutput ${NC}"
+      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
+      echo -e "$erroutput ${NC}" | tee $LOG
     fi
     if erroutput=$(rpm -e --nodeps Percona-Server-shared-51 2>&1); then
-      echo "Percona-Package erased"
+      echo "- Percona-Package erased" | tee $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package"
-      echo -e "$erroutput ${NC}"
+      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
+      echo -e "$erroutput ${NC}" | tee $LOG
     fi
     sed -i 's/^enabled = 1/enabled = 0/' /etc/yum.repos.d/percona-original-release.repo
   else
     # Removing MySQL 5.6 server
     if erroutput=$(rpm -e --nodeps mysql-server 2>&1); then
-      echo "removed mysql-server 5.6"
+      echo "- removed mysql-server 5.6" | tee $LOG
     else
-      echo -e "${RED}Failed to removed MySQL-server 5.6"
-      echo -e "$erroutput ${NC}"
+      echo -e "${RED}Failed to removed MySQL-server 5.6" | tee $LOG
+      echo -e "$erroutput ${NC}" | tee $LOG
       exit 1
     fi
   fi
@@ -210,7 +211,7 @@ case $MySQL_VERS_INFO in
   ;;
 
 *"Distrib 10.0"*)
-  echo "MariaDB 10.0 detected. Proceeding with upgrade to 10.5"
+  echo "MariaDB 10.0 detected. Proceeding with upgrade to 10.5" | tee $LOG
   mv -f /etc/my.cnf /etc/my.cnf.bak
   do_mariadb_upgrade '10.1'
   do_mariadb_upgrade '10.2'
@@ -218,32 +219,32 @@ case $MySQL_VERS_INFO in
   ;;
 
 *"Distrib 10.1"*)
-  echo "MariaDB 10.1 detected. Proceeding with upgrade to 10.5"
+  echo "MariaDB 10.1 detected. Proceeding with upgrade to 10.5" | tee $LOG
   do_mariadb_upgrade '10.2'
   do_mariadb_upgrade '10.5'
   ;;
 
 *"Distrib 10.2"*)
-  echo "MariaDB 10.2 detected. Proceeding with upgrade to 10.5"
+  echo "MariaDB 10.2 detected. Proceeding with upgrade to 10.5" | tee $LOG
   do_mariadb_upgrade '10.5'
   ;;
 
 *"Distrib 10.3"*)
-  echo "MariaDB 10.3 detected. Proceeding with upgrade to 10.5"
+  echo "MariaDB 10.3 detected. Proceeding with upgrade to 10.5" | tee $LOG
   do_mariadb_upgrade '10.5'
   ;;
 *"Distrib 10.4"*)
-  echo "MariaDB 10.4 detected. Proceeding with upgrade to 10.5"
+  echo "MariaDB 10.4 detected. Proceeding with upgrade to 10.5" | tee $LOG
   do_mariadb_upgrade '10.5'
   ;;
 
 *"Distrib 10.5"*)
-  echo "Already at 10.5. Exiting."
+  echo "Already at 10.5. Exiting." | tee $LOG
   exit 1
   ;;
 
 *)
-  echo "Error. Unknown initial MySQL version. Aborting."
+  echo "Error. Unknown initial MySQL version. Aborting." | tee $LOG
   exit 1
   ;;
 esac
@@ -269,7 +270,7 @@ fi
 # Link /var/log/mysqld.log to mariadb log file location
 ln -s /var/lib/mysql/mysqld.log /var/log/mysqld.log
 
-echo "Ensuring systemd doesn't mix up mysql and mariadb"
+echo "Ensuring systemd doesn't mix up mysql and mariadb" | tee $LOG
 systemctl stop mysql > /dev/null 2>&1
 systemctl stop mariadb > /dev/null 2>&1
 chkconfig --del mysql > /dev/null 2>&1
@@ -278,7 +279,7 @@ systemctl disable mariadb > /dev/null 2>&1
 systemctl enable mariadb.service > /dev/null 2>&1
 systemctl start mariadb.service > /dev/null 2>&1
 
-echo "Fixing Plesk bug MDEV-27834"
+echo "Fixing Plesk bug MDEV-27834" | tee $LOG
 # BUGFIX MDEV-27834: https://support.plesk.com/hc/en-us/articles/4419625529362-Plesk-Installer-fails-when-MariaDB-10-5-or-10-6-is-installed
 
 mdb_ver=$(rpm -q MariaDB-shared | awk -F- '{print $3}')
@@ -287,10 +288,10 @@ if echo "$mdb_ver" | grep -q 10.3.34; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
   if erroutput=$(yum -y -q downgrade MariaDB-shared-10.3.32 2>&1); then
-    echo "Bug fix: downgrade successful"
+    echo "- Bug fix: downgrade successful" | tee $LOG
   else
-    echo -e "${RED}Bug fix: downgrade failed"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Bug fix: downgrade failed" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
   echo "exclude=MariaDB-shared-10.3.34" >>/etc/yum.repos.d/mariadb.repo
@@ -299,10 +300,10 @@ elif echo "$mdb_ver" | grep -q 10.4.24; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
   if erroutput=$(yum -y -q downgrade MariaDB-shared-10.4.22 2>&1); then
-    echo "Bug fix: downgrade successful"
+    echo "- Bug fix: downgrade successful" | tee $LOG
   else
-    echo -e "${RED}Bug fix: downgrade failed"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Bug fix: downgrade failed" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
   echo "exclude=MariaDB-shared-10.4.24" >>/etc/yum.repos.d/mariadb.repo
@@ -311,10 +312,10 @@ elif echo "$mdb_ver" | grep -q 10.5.15; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
   if erroutput=$(yum -y -q downgrade MariaDB-shared-10.5.13 2>&1); then
-    echo "Bug fix: downgrade successful"
+    echo "- Bug fix: downgrade successful" | tee $LOG
   else
-    echo -e "${RED}Bug fix: downgrade failed"
-    echo -e "$erroutput ${NC}"
+    echo -e "${RED}Bug fix: downgrade failed" | tee $LOG
+    echo -e "$erroutput ${NC}" | tee $LOG
     exit 1
   fi
   echo "exclude=MariaDB-shared-10.5.15" >>/etc/yum.repos.d/mariadb.repo
@@ -325,13 +326,13 @@ fi
 
 # END BUGFIX
 
-echo "Informing Plesk of Changes"
+echo "Informing Plesk of Changes" | tee $LOG
 #plesk bin service_node --update local
 if erroutput=$(plesk sbin packagemng -sdf 2>&1); then
-  echo "Plesk informed of changes"
+  echo "- Plesk informed of changes" | tee $LOG
 else
-  echo -e "${RED}Failed to inform plesk of the changes"
-  echo -e "$erroutput ${NC}"
+  echo -e "${RED}Failed to inform plesk of the changes" | tee $LOG
+  echo -e "$erroutput ${NC}" | tee $LOG
 fi
 restorecon -v /var/lib/mysql/*
 

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -14,6 +14,7 @@ fi
 read -p "Are you sure you wish to proceed with the upgrade to MariaDB 10.5? (y/n) " -n 1 -r
 echo # new line
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  # shellcheck disable=SC2128
   [[ "$0" = "$BASH_SOURCE" ]] && exit 1 || return 1 # handle exits from shell or function but don't exit interactive shell
 fi
 
@@ -22,6 +23,7 @@ do_mariadb_upgrade() {
   MDB_VER=$1
   #MAJOR_VER=$(rpm --eval '%{rhel}')
   # Gets us ID and VERSION_ID vars
+  # shellcheck disable=SC1091
   source /etc/os-release
   MAJOR_VER="${VERSION_ID:0:1}" #ex: 7 or 8 rather than 7.4 or 8.4
 
@@ -81,7 +83,7 @@ case $MySQL_VERS_INFO in
 
 *"Distrib 5.6."*)
   echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5"
-
+  # shellcheck disable=SC2143
   if [[ $(rpm -qa | grep Percona-Server-server) ]]; then
     # Removing Percona server and disabling repo
     rpm -e --nodeps Percona-Server-server-56
@@ -176,19 +178,19 @@ echo "Fixing Plesk bug MDEV-27834"
 
 mdb_ver=$(rpm -q MariaDB-shared | awk -F- '{print $3}')
 
-if echo $mdb_ver | grep -q 10.3.34; then
+if echo "$mdb_ver" | grep -q 10.3.34; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
   yum -y downgrade MariaDB-shared-10.3.32
   echo "exclude=MariaDB-shared-10.3.34" >>/etc/yum.repos.d/mariadb.repo
 
-elif echo $mdb_ver | grep -q 10.4.24; then
+elif echo "$mdb_ver" | grep -q 10.4.24; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
   yum -y downgrade MariaDB-shared-10.4.22
   echo "exclude=MariaDB-shared-10.4.24" >>/etc/yum.repos.d/mariadb.repo
 
-elif echo $mdb_ver | grep -q 10.5.15; then
+elif echo "$mdb_ver" | grep -q 10.5.15; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
   yum -y downgrade MariaDB-shared-10.5.13

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -32,7 +32,19 @@ do_mariadb_upgrade() {
   echo "Beginning upgrade to MariaDB $MDB_VER..."
 
   DATE=$(date)
-  echo "# MariaDB $MDB_VER CentOS repository list - created $DATE
+  if [ "$MDB_VER" = "10.0" ]; then
+
+    echo "# MariaDB $MDB_VER CentOS repository list - created $DATE
+# 10.0.38 is the latest version in 10.0.x
+[mariadb]
+name = MariaDB
+baseurl = https://archive.mariadb.org/mariadb-10.0.38/yum/centos7-amd64/
+module_hotfixes=1
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
+
+  else
+    echo "# MariaDB $MDB_VER CentOS repository list - created $DATE
 # http://downloads.mariadb.org/mariadb/repositories/
 [mariadb]
 name = MariaDB
@@ -41,26 +53,26 @@ module_hotfixes=1
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
 
-  echo "- Clearing mariadb repo cache"
-  yum clean all --disablerepo="*" --enablerepo=mariadb
-  echo "- Stopping current db server"
-  systemctl stop mariadb || systemctl stop mysql
+    echo "- Clearing mariadb repo cache"
+    yum clean all --disablerepo="*" --enablerepo=mariadb
+    echo "- Stopping current db server"
+    systemctl stop mariadb || systemctl stop mysql
 
-  echo "- Removing packages"
-  rpm --quiet -e --nodeps MariaDB-server
-  rpm --quiet -e --nodeps mariadb-server
-  rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server
+    echo "- Removing packages"
+    rpm --quiet -e --nodeps MariaDB-server
+    rpm --quiet -e --nodeps mariadb-server
+    rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server
 
-  echo "- Updating and installing packages"
-  yum -y -q update MariaDB-*
-  yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
+    echo "- Updating and installing packages"
+    yum -y -q update MariaDB-*
+    yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
 
-  echo "- Starting MariaDB $MDB_VER"
-  systemctl restart mariadb
+    echo "- Starting MariaDB $MDB_VER"
+    systemctl restart mariadb
 
-  echo "- Running mysql_upgrade"
-  MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
-
+    echo "- Running mysql_upgrade"
+    MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
+  fi
 }
 
 MySQL_VERS_INFO=$(mysql --version)

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -270,13 +270,13 @@ fi
 ln -s /var/lib/mysql/mysqld.log /var/log/mysqld.log
 
 echo "Ensuring systemd doesn't mix up mysql and mariadb"
-systemctl stop mysql
-systemctl stop mariadb
-chkconfig --del mysql
-systemctl disable mysql
-systemctl disable mariadb
-systemctl enable mariadb.service
-systemctl start mariadb.service
+systemctl stop mysql > /dev/null 2>&1
+systemctl stop mariadb > /dev/null 2>&1
+chkconfig --del mysql > /dev/null 2>&1
+systemctl disable mysql > /dev/null 2>&1
+systemctl disable mariadb > /dev/null 2>&1
+systemctl enable mariadb.service > /dev/null 2>&1
+systemctl start mariadb.service > /dev/null 2>&1
 
 echo "Fixing Plesk bug MDEV-27834"
 # BUGFIX MDEV-27834: https://support.plesk.com/hc/en-us/articles/4419625529362-Plesk-Installer-fails-when-MariaDB-10-5-or-10-6-is-installed

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -47,9 +47,9 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   systemctl stop mariadb || systemctl stop mysql
 
   echo "- Removing packages"
-  rpm -e --nodeps MariaDB-server >/dev/null 2>&1
-  rpm -e --nodeps mariadb-server >/dev/null 2>&1
-  rpm -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server >/dev/null 2>&1
+  rpm --quiet -e --nodeps MariaDB-server
+  rpm --quiet -e --nodeps mariadb-server
+  rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server
 
   echo "- Updating and installing packages"
   yum -y -q update MariaDB-*

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -77,7 +77,6 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
 
   echo "- Running mysql_upgrade"
   MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
-  read -p "Func" -n 1 -r
 }
 
 MySQL_VERS_INFO=$(mysql --version)

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
 echo "Beginning upgrade procedure."
 
 read -p "Do you wish to back up all existing databases? (y/n) " -n 1 -r
 echo # new line
 if [[ ! $REPLY =~ ^[Nn]$ ]]; then
   echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."
-  MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysqldump -u admin --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz
+  if erroutput=$(mysqldump -u admin -p$(cat /etc/psa/.psa.shadow) --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz 2>&1); then
+    echo "Backups successfully created"
+  else
+    echo -e "${RED} Error:"
+    echo -e "$erroutput ${NC}"
+    exit 1
+  fi
 else
   echo "A risk taker, I see. Carrying on with upgrade procedures without backup..."
 fi

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -44,7 +44,7 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   echo "- Clearing mariadb repo cache"
   yum clean all --disablerepo="*" --enablerepo=mariadb
   echo "- Stopping current db server"
-  systemctl stop mysql
+  systemctl stop mariadb || systemctl stop mysql
 
   echo "- Removing packages"
   rpm -e --nodeps MariaDB-server >/dev/null 2>&1

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -106,6 +106,7 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   else
     echo -e "${RED}Failed to update MariaDB packages:"
     echo -e "$erroutput ${NC}"
+    exit 1
   fi
 
   if erroutput=$(yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server 2>&1); then

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -4,12 +4,12 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 LOG="/var/log/mairadb-upgrade.log"
 
-echo "Beginning upgrade procedure."
+echo "Beginning upgrade procedure." | tee $LOG
 
 read -p "Do you wish to back up all existing databases? (y/n) " -n 1 -r
 echo # new line
 if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-  echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."
+  echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."  | tee $LOG
   if erroutput=$(mysqldump -u admin -p$(cat /etc/psa/.psa.shadow) --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz 2>&1); then
     echo "- Backups successfully created" | tee $LOG
   else
@@ -18,7 +18,7 @@ if [[ ! $REPLY =~ ^[Nn]$ ]]; then
     exit 1
   fi
 else
-  echo "A risk taker, I see. Carrying on with upgrade procedures without backup..."
+  echo "A risk taker, I see. Carrying on with upgrade procedures without backup..." | tee $LOG
 fi
 
 read -p "Are you sure you wish to proceed with the upgrade to MariaDB 10.5? (y/n) " -n 1 -r

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -80,9 +80,15 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
   echo "- Removing packages"
-  rpm --quiet -e --nodeps MariaDB-server
-  rpm --quiet -e --nodeps mariadb-server
-  rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server
+  if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
+    echo -e "${RED} $erroutput ${NC}"
+  fi
+  if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
+    echo -e "${RED} $erroutput ${NC}"
+  fi
+  if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
+    echo -e "${RED} $erroutput ${NC}"
+  fi
 
   echo "- Updating and installing packages"
   yum -y -q update MariaDB-*

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -12,7 +12,7 @@ if [[ ! $REPLY =~ ^[Nn]$ ]]; then
   if erroutput=$(mysqldump -u admin -p$(cat /etc/psa/.psa.shadow) --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz 2>&1); then
     echo "Backups successfully created"
   else
-    echo -e "${RED} Error:"
+    echo -e "${RED}Error:"
     echo -e "$erroutput ${NC}"
     exit 1
   fi
@@ -66,7 +66,12 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
   echo "- Clearing mariadb repo cache"
-  yum clean all --disablerepo="*" --enablerepo=mariadb
+  if erroutput=$(yum clean all --disablerepo="*" --enablerepo=mariadb 2>&1); then
+    echo "mariadb repo cache cleared"
+  else
+    echo -e "${RED}Failed to clear mariadb repo cache"
+    echo -e "$erroutput ${NC}"
+  fi
   echo "- Stopping current db server"
   systemctl stop mariadb || systemctl stop mysql
 

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -81,15 +81,18 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
   echo "- Removing packages"
-  if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
-    echo "MariaDB-server package erased"
+  if rpm -qa | grep "MariaDB-server" > /dev/null 2>&1; then
+    if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
+      echo "MariaDB-server package erased"
+    else
+      echo -e "${RED}$erroutput ${NC}"
+    fi
   else
-    echo -e "${RED}$erroutput ${NC}"
-  fi
-  if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
-    echo "MariaDB-server package erased"
-  else
-    echo -e "${RED}$erroutput ${NC}"
+    if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
+      echo "MariaDB-server package erased"
+    else
+      echo -e "${RED}$erroutput ${NC}"
+    fi
   fi
   if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
     echo "MariaDB packages erased"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -299,7 +299,12 @@ fi
 
 echo "Informing Plesk of Changes"
 #plesk bin service_node --update local
-plesk sbin packagemng -sdf
+if erroutput=$(plesk sbin packagemng -sdf 2>&1); then
+  echo "Plesk informed of changes"
+else
+  echo -e "${RED}Failed to inform plesk of the changes"
+  echo -e "$erroutput ${NC}"
+fi
 restorecon -v /var/lib/mysql/*
 
 systemctl restart sw-cp-server

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -84,18 +84,17 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
     echo "MariaDB-server package erased"
   else
-    echo -e "${RED} $erroutput ${NC}"
+    echo -e "${RED}$erroutput ${NC}"
   fi
   if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
     echo "MariaDB-server package erased"
   else
-    echo -e "${RED} $erroutput ${NC}"
+    echo -e "${RED}$erroutput ${NC}"
   fi
   if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
     echo "MariaDB packages erased"
   else
-    echo -e "${RED} $erroutput ${NC}"
-    exit 1
+    echo -e "${RED}$erroutput ${NC}"
   fi
 
   echo "- Updating and installing packages"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -107,7 +107,14 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
     echo -e "${RED}Failed to update MariaDB packages:"
     echo -e "$erroutput ${NC}"
   fi
-  yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
+
+  if erroutput=$(yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server 2>&1); then
+    echo "MariaDB-server $MDB_VER successfully installed"
+  else
+    echo -e "${RED}Failed to installed MariaDB $MDB_VERw"
+    echo -e "$erroutput ${NC}"
+    exit 1
+  fi
 
   echo "- Starting MariaDB $MDB_VER"
   if [ "$MDB_VER" = "10.0" ]; then

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -95,7 +95,12 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
   echo "- Updating and installing packages"
-  yum -y -q update MariaDB-*
+  if erroutput=$(yum -y -q update MariaDB-* 2>&1); then
+    echo "MariaDB packages updated"  
+  else
+    echo -e "${RED}Failed to update MariaDB packages:"
+    echo -e "$erroutput ${NC}"
+  fi
   yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
 
   echo "- Starting MariaDB $MDB_VER"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -4,21 +4,21 @@ RED='\033[0;31m'
 NC='\033[0m' # No Color
 LOG="/var/log/mariadb-upgrade.log"
 
-echo "Beginning upgrade procedure." | tee $LOG
+echo "Beginning upgrade procedure." | tee -a $LOG
 
 read -p "Do you wish to back up all existing databases? (y/n) " -n 1 -r
 echo # new line
 if [[ ! $REPLY =~ ^[Nn]$ ]]; then
-  echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."  | tee $LOG
+  echo "Proceeding with backup to /root/all_databases_pre_maria_upgrade.sql.gz ... This may take 5 minutes or so depending on size of databases."  | tee -a $LOG
   if erroutput=$(mysqldump -u admin -p$(cat /etc/psa/.psa.shadow) --all-databases --routines --triggers --max_allowed_packet=1G | gzip >/root/all_databases_pre_maria_upgrade.sql.gz 2>&1); then
-    echo "- Backups successfully created" | tee $LOG
+    echo "- Backups successfully created" | tee -a $LOG
   else
-    echo -e "${RED}Error:" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Error:" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
 else
-  echo "A risk taker, I see. Carrying on with upgrade procedures without backup..." | tee $LOG
+  echo "A risk taker, I see. Carrying on with upgrade procedures without backup..." | tee -a $LOG
 fi
 
 read -p "Are you sure you wish to proceed with the upgrade to MariaDB 10.5? (y/n) " -n 1 -r
@@ -41,7 +41,7 @@ do_mariadb_upgrade() {
     ID=rhel; 
   fi
 
-  echo "Beginning upgrade to MariaDB $MDB_VER..." | tee $LOG
+  echo "Beginning upgrade to MariaDB $MDB_VER..." | tee -a $LOG
 
   DATE=$(date)
   if [ "$MDB_VER" = "10.0" ]; then
@@ -66,15 +66,15 @@ gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
-  echo "- Clearing mariadb repo cache" | tee $LOG
+  echo "- Clearing mariadb repo cache" | tee -a $LOG
   if erroutput=$(yum clean all --disablerepo="*" --enablerepo=mariadb 2>&1); then
-    echo "- mariadb repo cache cleared" | tee $LOG
+    echo "- mariadb repo cache cleared" | tee -a $LOG
   else
-    echo -e "${RED}Failed to clear mariadb repo cache" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Failed to clear mariadb repo cache" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
-  echo "- Stopping current db server" | tee $LOG
+  echo "- Stopping current db server" | tee -a $LOG
   if systemctl | grep -i "mariadb.service"; then
     systemctl stop mariadb
   elif systemctl | grep -i "mysql.service"; then
@@ -84,15 +84,15 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   echo "- Removing packages"
   if rpm -qa | grep "MariaDB-server" > /dev/null 2>&1; then
     if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
-      echo "- MariaDB-server package erased" | tee $LOG
+      echo "- MariaDB-server package erased" | tee -a $LOG
     else
-      echo -e "${RED}$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}$erroutput ${NC}" | tee -a $LOG
     fi
   else
     if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
-      echo "- MariaDB-server package erased" | tee $LOG
+      echo "- MariaDB-server package erased" | tee -a $LOG
     else
-      echo -e "${RED}$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}$erroutput ${NC}" | tee -a $LOG
     fi
   fi
   installed_packages=$(rpm -qa)
@@ -103,26 +103,26 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   done
   if [ ! -z $mariadb_rpm ]; then
     if erroutput=$(rpm --quiet -e --nodeps $mariadb_rpm 2>&1); then
-      echo "- MariaDB packages erased" | tee $LOG
+      echo "- MariaDB packages erased" | tee -a $LOG
     else
-      echo -e "${RED}$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}$erroutput ${NC}" | tee -a $LOG
     fi
   fi
 
   echo "- Updating and installing packages"
   if erroutput=$(yum -y -q update MariaDB-* 2>&1); then
-    echo "- MariaDB packages updated" | tee $LOG
+    echo "- MariaDB packages updated" | tee -a $LOG
   else
-    echo -e "${RED}Failed to update MariaDB packages:" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Failed to update MariaDB packages:" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
 
   if erroutput=$(yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server 2>&1); then
-    echo "- MariaDB-server $MDB_VER successfully installed" | tee $LOG
+    echo "- MariaDB-server $MDB_VER successfully installed" | tee -a $LOG
   else
-    echo -e "${RED}Failed to installed MariaDB $MDB_VER" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Failed to installed MariaDB $MDB_VER" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
 
@@ -135,10 +135,10 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
 
   echo "- Running mysql_upgrade"
   if erroutput=$(mysql_upgrade -u admin -p$(cat /etc/psa/.psa.shadow) 2>&1); then
-    echo "- MySQL/MariaDB upgrade to $MDB_VER was Successful" | tee $LOG
+    echo "- MySQL/MariaDB upgrade to $MDB_VER was Successful" | tee -a $LOG
   else
-    echo -e "${RED}Failed to upgrade to MySQL/MariaDB $MDB_VER" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Failed to upgrade to MySQL/MariaDB $MDB_VER" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
 }
@@ -162,42 +162,42 @@ case $MySQL_VERS_INFO in
   ;;
 
 *"Distrib 5.6."*)
-  echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5" | tee $LOG
+  echo "MySQL or Percona 5.6 detected. Proceeding with 5.6 -> 10.0 -> 10.5" | tee -a $LOG
   # shellcheck disable=SC2143
   if [[ $(rpm -qa | grep Percona-Server-server) ]]; then
     # Removing Percona server and disabling repo
     if erroutput=$(rpm -e --nodeps Percona-Server-server-56 2>&1); then
-      echo "- Percona-Package erased" | tee $LOG
+      echo "- Percona-Package erased" | tee -a $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
-      echo -e "$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}Failed to erase Percona-Package" | tee -a $LOG
+      echo -e "$erroutput ${NC}" | tee -a $LOG
     fi
     if erroutput=$(rpm -e --nodeps Percona-Server-shared-56 2>&1); then
-      echo "- Percona-Package erased" | tee $LOG
+      echo "- Percona-Package erased" | tee -a $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
-      echo -e "$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}Failed to erase Percona-Package" | tee -a $LOG
+      echo -e "$erroutput ${NC}" | tee -a $LOG
     fi
     if erroutput=$(rpm -e --nodeps Percona-Server-client-56 2>&1); then
-      echo "- Percona-Package erased" | tee $LOG
+      echo "- Percona-Package erased" | tee -a $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
-      echo -e "$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}Failed to erase Percona-Package" | tee -a $LOG
+      echo -e "$erroutput ${NC}" | tee -a $LOG
     fi
     if erroutput=$(rpm -e --nodeps Percona-Server-shared-51 2>&1); then
-      echo "- Percona-Package erased" | tee $LOG
+      echo "- Percona-Package erased" | tee -a $LOG
     else
-      echo -e "${RED}Failed to erase Percona-Package" | tee $LOG
-      echo -e "$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}Failed to erase Percona-Package" | tee -a $LOG
+      echo -e "$erroutput ${NC}" | tee -a $LOG
     fi
     sed -i 's/^enabled = 1/enabled = 0/' /etc/yum.repos.d/percona-original-release.repo
   else
     # Removing MySQL 5.6 server
     if erroutput=$(rpm -e --nodeps mysql-server 2>&1); then
-      echo "- removed mysql-server 5.6" | tee $LOG
+      echo "- removed mysql-server 5.6" | tee -a $LOG
     else
-      echo -e "${RED}Failed to removed MySQL-server 5.6" | tee $LOG
-      echo -e "$erroutput ${NC}" | tee $LOG
+      echo -e "${RED}Failed to removed MySQL-server 5.6" | tee -a $LOG
+      echo -e "$erroutput ${NC}" | tee -a $LOG
       exit 1
     fi
   fi
@@ -211,7 +211,7 @@ case $MySQL_VERS_INFO in
   ;;
 
 *"Distrib 10.0"*)
-  echo "MariaDB 10.0 detected. Proceeding with upgrade to 10.5" | tee $LOG
+  echo "MariaDB 10.0 detected. Proceeding with upgrade to 10.5" | tee -a $LOG
   mv -f /etc/my.cnf /etc/my.cnf.bak
   do_mariadb_upgrade '10.1'
   do_mariadb_upgrade '10.2'
@@ -219,32 +219,32 @@ case $MySQL_VERS_INFO in
   ;;
 
 *"Distrib 10.1"*)
-  echo "MariaDB 10.1 detected. Proceeding with upgrade to 10.5" | tee $LOG
+  echo "MariaDB 10.1 detected. Proceeding with upgrade to 10.5" | tee -a $LOG
   do_mariadb_upgrade '10.2'
   do_mariadb_upgrade '10.5'
   ;;
 
 *"Distrib 10.2"*)
-  echo "MariaDB 10.2 detected. Proceeding with upgrade to 10.5" | tee $LOG
+  echo "MariaDB 10.2 detected. Proceeding with upgrade to 10.5" | tee -a $LOG
   do_mariadb_upgrade '10.5'
   ;;
 
 *"Distrib 10.3"*)
-  echo "MariaDB 10.3 detected. Proceeding with upgrade to 10.5" | tee $LOG
+  echo "MariaDB 10.3 detected. Proceeding with upgrade to 10.5" | tee -a $LOG
   do_mariadb_upgrade '10.5'
   ;;
 *"Distrib 10.4"*)
-  echo "MariaDB 10.4 detected. Proceeding with upgrade to 10.5" | tee $LOG
+  echo "MariaDB 10.4 detected. Proceeding with upgrade to 10.5" | tee -a $LOG
   do_mariadb_upgrade '10.5'
   ;;
 
 *"Distrib 10.5"*)
-  echo "Already at 10.5. Exiting." | tee $LOG
+  echo "Already at 10.5. Exiting." | tee -a $LOG
   exit 1
   ;;
 
 *)
-  echo "Error. Unknown initial MySQL version. Aborting." | tee $LOG
+  echo "Error. Unknown initial MySQL version. Aborting." | tee -a $LOG
   exit 1
   ;;
 esac
@@ -270,7 +270,7 @@ fi
 # Link /var/log/mysqld.log to mariadb log file location
 ln -s /var/lib/mysql/mysqld.log /var/log/mysqld.log
 
-echo "Ensuring systemd doesn't mix up mysql and mariadb" | tee $LOG
+echo "Ensuring systemd doesn't mix up mysql and mariadb" | tee -a $LOG
 systemctl stop mysql > /dev/null 2>&1
 systemctl stop mariadb > /dev/null 2>&1
 chkconfig --del mysql > /dev/null 2>&1
@@ -279,7 +279,7 @@ systemctl disable mariadb > /dev/null 2>&1
 systemctl enable mariadb.service > /dev/null 2>&1
 systemctl start mariadb.service > /dev/null 2>&1
 
-echo "Fixing Plesk bug MDEV-27834" | tee $LOG
+echo "Fixing Plesk bug MDEV-27834" | tee -a $LOG
 # BUGFIX MDEV-27834: https://support.plesk.com/hc/en-us/articles/4419625529362-Plesk-Installer-fails-when-MariaDB-10-5-or-10-6-is-installed
 
 mdb_ver=$(rpm -q MariaDB-shared | awk -F- '{print $3}')
@@ -288,10 +288,10 @@ if echo "$mdb_ver" | grep -q 10.3.34; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
   if erroutput=$(yum -y -q downgrade MariaDB-shared-10.3.32 2>&1); then
-    echo "- Bug fix: downgrade successful" | tee $LOG
+    echo "- Bug fix: downgrade successful" | tee -a $LOG
   else
-    echo -e "${RED}Bug fix: downgrade failed" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Bug fix: downgrade failed" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
   echo "exclude=MariaDB-shared-10.3.34" >>/etc/yum.repos.d/mariadb.repo
@@ -300,10 +300,10 @@ elif echo "$mdb_ver" | grep -q 10.4.24; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
   if erroutput=$(yum -y -q downgrade MariaDB-shared-10.4.22 2>&1); then
-    echo "- Bug fix: downgrade successful" | tee $LOG
+    echo "- Bug fix: downgrade successful" | tee -a $LOG
   else
-    echo -e "${RED}Bug fix: downgrade failed" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Bug fix: downgrade failed" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
   echo "exclude=MariaDB-shared-10.4.24" >>/etc/yum.repos.d/mariadb.repo
@@ -312,10 +312,10 @@ elif echo "$mdb_ver" | grep -q 10.5.15; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
   if erroutput=$(yum -y -q downgrade MariaDB-shared-10.5.13 2>&1); then
-    echo "- Bug fix: downgrade successful" | tee $LOG
+    echo "- Bug fix: downgrade successful" | tee -a $LOG
   else
-    echo -e "${RED}Bug fix: downgrade failed" | tee $LOG
-    echo -e "$erroutput ${NC}" | tee $LOG
+    echo -e "${RED}Bug fix: downgrade failed" | tee -a $LOG
+    echo -e "$erroutput ${NC}" | tee -a $LOG
     exit 1
   fi
   echo "exclude=MariaDB-shared-10.5.15" >>/etc/yum.repos.d/mariadb.repo
@@ -326,13 +326,13 @@ fi
 
 # END BUGFIX
 
-echo "Informing Plesk of Changes" | tee $LOG
+echo "Informing Plesk of Changes" | tee -a $LOG
 #plesk bin service_node --update local
 if erroutput=$(plesk sbin packagemng -sdf 2>&1); then
-  echo "- Plesk informed of changes" | tee $LOG
+  echo "- Plesk informed of changes" | tee -a $LOG
 else
-  echo -e "${RED}Failed to inform plesk of the changes" | tee $LOG
-  echo -e "$erroutput ${NC}" | tee $LOG
+  echo -e "${RED}Failed to inform plesk of the changes" | tee -a $LOG
+  echo -e "$erroutput ${NC}" | tee -a $LOG
 fi
 restorecon -v /var/lib/mysql/*
 

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -82,12 +82,15 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   echo "- Removing packages"
   if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
     echo -e "${RED} $erroutput ${NC}"
+    exit 1
   fi
   if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
     echo -e "${RED} $erroutput ${NC}"
+    exit 1
   fi
   if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
     echo -e "${RED} $erroutput ${NC}"
+    exit 1
   fi
 
   echo "- Updating and installing packages"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -2,7 +2,7 @@
 
 RED='\033[0;31m'
 NC='\033[0m' # No Color
-LOG="/var/log/mairadb-upgrade.log"
+LOG="/var/log/mariadb-upgrade.log"
 
 echo "Beginning upgrade procedure." | tee $LOG
 

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -94,8 +94,9 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
       echo -e "${RED}$erroutput ${NC}"
     fi
   fi
+  installed_packages=$(rpm -qa)
   for i in "mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server"; do
-    if rpm -qa | grep "$i" > /dev/null 2>&1; then
+    if echo "$installed_packages" | grep "$i" > /dev/null 2>&1; then
       mariadb_rpm="$mariadb_rpm $i"
     fi
   done

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -85,13 +85,11 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
     echo "MariaDB-server package erased"
   else
     echo -e "${RED} $erroutput ${NC}"
-    exit 1
   fi
   if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
     echo "MariaDB-server package erased"
   else
     echo -e "${RED} $erroutput ${NC}"
-    exit 1
   fi
   if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
     echo "MariaDB packages erased"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -82,14 +82,20 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
 
   echo "- Removing packages"
   if erroutput=$(rpm --quiet -e --nodeps MariaDB-server 2>&1); then
+    echo "MariaDB-server package erased"
+  else
     echo -e "${RED} $erroutput ${NC}"
     exit 1
   fi
   if erroutput=$(rpm --quiet -e --nodeps mariadb-server 2>&1); then
+    echo "MariaDB-server package erased"
+  else
     echo -e "${RED} $erroutput ${NC}"
     exit 1
   fi
   if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
+    echo "MariaDB packages erased"
+  else
     echo -e "${RED} $erroutput ${NC}"
     exit 1
   fi

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -52,27 +52,27 @@ baseurl = http://yum.mariadb.org/$MDB_VER/$ID$MAJOR_VER-amd64
 module_hotfixes=1
 gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
-
-    echo "- Clearing mariadb repo cache"
-    yum clean all --disablerepo="*" --enablerepo=mariadb
-    echo "- Stopping current db server"
-    systemctl stop mariadb || systemctl stop mysql
-
-    echo "- Removing packages"
-    rpm --quiet -e --nodeps MariaDB-server
-    rpm --quiet -e --nodeps mariadb-server
-    rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server
-
-    echo "- Updating and installing packages"
-    yum -y -q update MariaDB-*
-    yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
-
-    echo "- Starting MariaDB $MDB_VER"
-    systemctl restart mariadb
-
-    echo "- Running mysql_upgrade"
-    MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
   fi
+
+  echo "- Clearing mariadb repo cache"
+  yum clean all --disablerepo="*" --enablerepo=mariadb
+  echo "- Stopping current db server"
+  systemctl stop mariadb || systemctl stop mysql
+
+  echo "- Removing packages"
+  rpm --quiet -e --nodeps MariaDB-server
+  rpm --quiet -e --nodeps mariadb-server
+  rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server
+
+  echo "- Updating and installing packages"
+  yum -y -q update MariaDB-*
+  yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
+
+  echo "- Starting MariaDB $MDB_VER"
+  systemctl restart mariadb
+
+  echo "- Running mysql_upgrade"
+  MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
 }
 
 MySQL_VERS_INFO=$(mysql --version)

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -94,10 +94,17 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
       echo -e "${RED}$erroutput ${NC}"
     fi
   fi
-  if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
-    echo "MariaDB packages erased"
-  else
-    echo -e "${RED}$erroutput ${NC}"
+  for i in "mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server"; do
+    if rpm -qa | grep "$i" > /dev/null 2>&1; then
+      mariadb_rpm="$mariadb_rpm $i"
+    fi
+  done
+  if [ ! -z $mariadb_rpm ]; then
+    if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
+      echo "MariaDB packages erased"
+    else
+      echo -e "${RED}$erroutput ${NC}"
+    fi
   fi
 
   echo "- Updating and installing packages"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -157,10 +157,30 @@ case $MySQL_VERS_INFO in
   # shellcheck disable=SC2143
   if [[ $(rpm -qa | grep Percona-Server-server) ]]; then
     # Removing Percona server and disabling repo
-    rpm -e --nodeps Percona-Server-server-56
-    rpm -e --nodeps Percona-Server-shared-56
-    rpm -e --nodeps Percona-Server-client-56
-    rpm -e --nodeps Percona-Server-shared-51
+    if erroutput=$(rpm -e --nodeps Percona-Server-server-56 2>&1); then
+      echo "Percona-Package erased"
+    else
+      echo -e "${RED}Failed to erase Percona-Package"
+      echo -e "$erroutput ${NC}"
+    fi
+    if erroutput=$(rpm -e --nodeps Percona-Server-shared-56 2>&1); then
+      echo "Percona-Package erased"
+    else
+      echo -e "${RED}Failed to erase Percona-Package"
+      echo -e "$erroutput ${NC}"
+    fi
+    if erroutput=$(rpm -e --nodeps Percona-Server-client-56 2>&1); then
+      echo "Percona-Package erased"
+    else
+      echo -e "${RED}Failed to erase Percona-Package"
+      echo -e "$erroutput ${NC}"
+    fi
+    if erroutput=$(rpm -e --nodeps Percona-Server-shared-51 2>&1); then
+      echo "Percona-Package erased"
+    else
+      echo -e "${RED}Failed to erase Percona-Package"
+      echo -e "$erroutput ${NC}"
+    fi
     sed -i 's/^enabled = 1/enabled = 0/' /etc/yum.repos.d/percona-original-release.repo
   else
     # Removing MySQL 5.6 server

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -69,10 +69,15 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server
 
   echo "- Starting MariaDB $MDB_VER"
-  systemctl restart mariadb
+  if [ "$MDB_VER" = "10.0" ]; then
+    systemctl restart mysql
+  else
+    systemctl restart mariadb
+  fi
 
   echo "- Running mysql_upgrade"
   MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
+  read -p "Func" -n 1 -r
 }
 
 MySQL_VERS_INFO=$(mysql --version)

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -100,7 +100,7 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
     fi
   done
   if [ ! -z $mariadb_rpm ]; then
-    if erroutput=$(rpm --quiet -e --nodeps mysql-common mysql-libs mysql-devel mariadb-backup mariadb-gssapi-server 2>&1); then
+    if erroutput=$(rpm --quiet -e --nodeps $mariadb_rpm 2>&1); then
       echo "MariaDB packages erased"
     else
       echo -e "${RED}$erroutput ${NC}"

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -112,7 +112,7 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   if erroutput=$(yum -y -q install MariaDB-server MariaDB MariaDB-gssapi-server 2>&1); then
     echo "MariaDB-server $MDB_VER successfully installed"
   else
-    echo -e "${RED}Failed to installed MariaDB $MDB_VERw"
+    echo -e "${RED}Failed to installed MariaDB $MDB_VER"
     echo -e "$erroutput ${NC}"
     exit 1
   fi
@@ -125,7 +125,13 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   fi
 
   echo "- Running mysql_upgrade"
-  MYSQL_PWD=$(cat /etc/psa/.psa.shadow) mysql_upgrade -uadmin
+  if erroutput=$(mysql_upgrade -u admin -p$(cat /etc/psa/.psa.shadow) 2>&1); then
+    echo "MySQL/MariaDB upgrade to $MDB_VER was Successful"
+  else
+    echo -e "${RED}Failed to upgrade to MySQL/MariaDB $MDB_VER"
+    echo -e "$erroutput ${NC}"
+    exit 1
+  fi
 }
 
 MySQL_VERS_INFO=$(mysql --version)

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -71,6 +71,7 @@ gpgcheck=1" >/etc/yum.repos.d/mariadb.repo
   else
     echo -e "${RED}Failed to clear mariadb repo cache"
     echo -e "$erroutput ${NC}"
+    exit 1
   fi
   echo "- Stopping current db server"
   if systemctl | grep -i "mariadb.service"; then

--- a/mariadb-upgrade.sh
+++ b/mariadb-upgrade.sh
@@ -258,19 +258,37 @@ mdb_ver=$(rpm -q MariaDB-shared | awk -F- '{print $3}')
 if echo "$mdb_ver" | grep -q 10.3.34; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.3/rhel8-amd64/rpms/MariaDB-shared-10.3.32-1.el8.x86_64.rpm
-  yum -y -q downgrade MariaDB-shared-10.3.32
+  if erroutput=$(yum -y -q downgrade MariaDB-shared-10.3.32 2>&1); then
+    echo "Bug fix: downgrade successful"
+  else
+    echo -e "${RED}Bug fix: downgrade failed"
+    echo -e "$erroutput ${NC}"
+    exit 1
+  fi
   echo "exclude=MariaDB-shared-10.3.34" >>/etc/yum.repos.d/mariadb.repo
 
 elif echo "$mdb_ver" | grep -q 10.4.24; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.4/rhel8-amd64/rpms/MariaDB-shared-10.4.22-1.el8.x86_64.rpm
-  yum -y -q downgrade MariaDB-shared-10.4.22
+  if erroutput=$(yum -y -q downgrade MariaDB-shared-10.4.22 2>&1); then
+    echo "Bug fix: downgrade successful"
+  else
+    echo -e "${RED}Bug fix: downgrade failed"
+    echo -e "$erroutput ${NC}"
+    exit 1
+  fi
   echo "exclude=MariaDB-shared-10.4.24" >>/etc/yum.repos.d/mariadb.repo
 
 elif echo "$mdb_ver" | grep -q 10.5.15; then
 
   #rpm -Uhv --oldpackage --justdb http://yum.mariadb.org/10.5/rhel8-amd64/rpms/MariaDB-shared-10.5.13-1.el8.x86_64.rpm
-  yum -y -q downgrade MariaDB-shared-10.5.13
+  if erroutput=$(yum -y -q downgrade MariaDB-shared-10.5.13 2>&1); then
+    echo "Bug fix: downgrade successful"
+  else
+    echo -e "${RED}Bug fix: downgrade failed"
+    echo -e "$erroutput ${NC}"
+    exit 1
+  fi
   echo "exclude=MariaDB-shared-10.5.15" >>/etc/yum.repos.d/mariadb.repo
 
 fi


### PR DESCRIPTION
Updating from 5.5 was broken.

- Script couldn't start & repair 10.0. 
- 10.0 is EOL and not available on mirrors anymore. repo needs to be put to archive

I have enabled [shellcheck.net](https://www.shellcheck.net/) and added a GH action to make sure that future commits respect it.